### PR TITLE
Enabling XMLBuilder to handle creation of time primitives and documents inside folders

### DIFF
--- a/libKML/KMLBuilder.php
+++ b/libKML/KMLBuilder.php
@@ -64,7 +64,7 @@ namespace libKML;
     $containerContent = $containerXMLObject->children();
     
     $object_properties = array('NetworkLink', 'Placemark', 'PhotoOverlay', 'ScreenOverlay', 'GroundOverlay',
-                               'Folder');
+                               'Folder', 'Document');
     
     foreach($containerContent as $key => $value) {
       if (in_array($key, $object_properties)) {
@@ -644,6 +644,16 @@ namespace libKML;
     return $kml;
   }
   
+  function buildTimeStamp($kmlXMLObject) {
+    $kml = new TimeStamp();
+    $kml->setWhen($kmlXMLObject->when);
+    return $kml;
+  }
 
-
+  function buildTimeSpan($kmlXMLObject) {
+    $kml = new TimeSpan();
+    $kml->setBegin($kmlXMLObject->begin);
+    $kml->setEnd($kmlXMLObject->end);
+    return $kml;
+  }
 ?>

--- a/libKML/time/TimePrimitive.php
+++ b/libKML/time/TimePrimitive.php
@@ -5,5 +5,9 @@ namespace libKML;
  *  TimePrimitive abstract class
  */
 
-abstract class TimePrimitive extends KMLObject {}
+abstract class TimePrimitive extends KMLObject {
+    public function __toString() {
+      return "";
+    }
+}
 ?>

--- a/libkml.php
+++ b/libkml.php
@@ -86,6 +86,9 @@ include_once('libKML/views/AbstractView.php');
 include_once('libKML/views/Camera.php');
 include_once('libKML/views/LookAt.php');
 include_once('libKML/KMLBuilder.php');
+include_once('libKML/time/TimePrimitive.php');
+include_once('libKML/time/TimeSpan.php');
+include_once('libKML/time/TimeStamp.php');
 
 
 function parseKML($data) {

--- a/test/phpunit_test_time.php
+++ b/test/phpunit_test_time.php
@@ -1,0 +1,30 @@
+<?php
+
+require __DIR__ . '/../libkml.php';
+
+class TimePrimitiveTest extends PHPUnit_Framework_TestCase
+{
+
+  const SAMPLE_KML = __DIR__ . '/sample-time.kml';
+
+  public function testKmlParsing()
+  {
+    // Checking if the document was correctly parsed.
+    $kml_data = file_get_contents(self::SAMPLE_KML);
+    $kml = KML::createFromText($kml_data);
+    $features = $kml->getAllFeatures();
+    $this->assertNotEmpty($kml);
+    $folder = $kml->getFeature();
+    $this->assertNotEmpty($folder);
+    $document = $folder->getFeatures()[0];
+    $this->assertNotEmpty($folder);
+    $placemarks = $document->getFeatures();
+    $this->assertNotEmpty($placemarks);
+
+    // Checking if the TimeStamp and TimeSpan are converted to xml correctly.
+    foreach(array('TimeStamp', 'TimeSpan') as $i => $tag) {
+      $str = $placemarks[$i]->__toString();
+      $this->assertRegExp("/$tag/", $str);
+    }
+  }
+}

--- a/test/sample-time.kml
+++ b/test/sample-time.kml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2"
+ xmlns:gx="http://www.google.com/kml/ext/2.2">
+
+<Folder>
+
+  <name>Document inside a Folder and Placemark with TimeStamp</name>
+  <open>1</open>
+  <Style>
+    <BalloonStyle>
+      <textColor>ff000000</textColor>
+      <bgColor>ffffffff</bgColor>
+      <displayMode>default</displayMode>
+    </BalloonStyle>
+  </Style>
+
+  <Document>
+    <name>gx:AnimatedUpdate example</name>
+
+    <Style id="pushpin">
+      <IconStyle id="mystyle">
+        <Icon>
+          <href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+          <scale>1.0</scale>
+        </Icon>
+      </IconStyle>
+    </Style>
+
+    <Placemark id="mountainpin1">
+      <name>Pin on a mountaintop</name>
+      <styleUrl>#pushpin</styleUrl>
+        <TimeStamp><when>2009-07-28T17:32:43Z</when></TimeStamp>
+      <Point>
+        <coordinates>170.1435558771009,-43.60505741890396,0</coordinates>
+      </Point>
+    </Placemark>
+
+    <Placemark id="mountainpin2">
+      <name>Pin on a mountaintop</name>
+      <styleUrl>#pushpin</styleUrl>
+      <TimeSpan>
+        <begin>2009-07-28T17:32:43Z</begin>
+        <end>2009-07-28T17:35:43Z</end>
+      </TimeSpan>
+      <Point>
+        <coordinates>170.1435558771009,-43.60505741890396,0</coordinates>
+      </Point>
+    </Placemark>
+
+    <gx:Tour>
+      <name>Play me!</name>
+
+      <gx:Playlist>
+
+        <gx:FlyTo>
+          <gx:flyToMode>bounce</gx:flyToMode>
+          <gx:duration>3</gx:duration>
+          <Camera>
+            <longitude>170.157</longitude>
+            <latitude>-43.671</latitude>
+            <altitude>9700</altitude>
+            <heading>-6.333</heading>
+            <tilt>33.5</tilt>
+          </Camera>
+        </gx:FlyTo>
+
+        <gx:AnimatedUpdate>
+          <gx:duration>5</gx:duration>
+          <Update>
+            <targetHref></targetHref>
+            <Change>
+              <IconStyle targetId="mystyle">
+                <scale>10.0</scale>
+              </IconStyle>
+            </Change>
+          </Update>
+        </gx:AnimatedUpdate>
+
+        <gx:Wait>
+          <gx:duration>5</gx:duration>
+        </gx:Wait>
+
+      </gx:Playlist>
+    </gx:Tour>
+
+  </Document>
+
+</Folder>
+</kml>


### PR DESCRIPTION
Hey earelin!
I stumbled upon your little KML lib and found it useful for a little project of mine. However, my kml files included Placemarks with TimeStamps. It turned out that your library could not handle them as I expected (or I misread the docs). I patched the lib to add support for TimePrimitives during parsing / serialization. I also created a little test to check if it worked. The test could be run with phpunit. I hope you will find this patch useful. Anyways, thanks for creating and sharing the lib!